### PR TITLE
missing currency in reverse() method when proto>1

### DIFF
--- a/src/Borica/Request.php
+++ b/src/Borica/Request.php
@@ -193,6 +193,10 @@ class Request
         $message .= $this->getLanguage();
         $message .= $this->verifyProtocolVersion($protocolVersion) ? $protocolVersion : '1.0';
 
+        if ($protocolVersion != '1.0') {
+            $message .= $this->getCurrency();
+        }
+        
         $message = $this->signMessage($message);
 
         return "{$this->getGatewayURL()}manageTransaction?eBorica=" . urlencode(base64_encode($message));


### PR DESCRIPTION
the reverse() method was missing the currency in the message when protocol version > 1